### PR TITLE
Use `is-callable` for a reliable function test across older engines as well

### DIFF
--- a/blue-tape.js
+++ b/blue-tape.js
@@ -1,7 +1,8 @@
 var Test = require('tape/lib/test');
+var isCallable = require('is-callable');
 
 function checkPromise(p) {
-    return p && p.then && typeof p.then === 'function';
+    return p && isCallable(p.then);
 }
 
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "author": "spion",
   "license": "MIT",
   "dependencies": {
-    "tape": ">=2.0.0 <5.0.0"
+    "tape": ">=2.0.0 <5.0.0",
+    "is-callable": "^1.0.4"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
Fixes #7.