### PR TITLE
Add bin script

### DIFF
--- a/bin/blue-tape.js
+++ b/bin/blue-tape.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('tape/bin/tape');

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.9",
   "description": "Tape test runner with promise support",
   "main": "blue-tape.js",
+  "bin": {
+    "blue-tape": "./bin/blue-tape.js"
+  },
   "scripts": {
     "test": "set -e; for test in test/*.js; do node $test; done"
   },


### PR DESCRIPTION
Tape supports running tests from CLI with glob support.

Like: `tape test/**/*.js`

Since `blue-tape` is supposed to be a replacement for `tape`, CLI support is also necessary.