### PR TITLE
Get rid of `nextTick`

### DIFF
--- a/blue-tape.js
+++ b/blue-tape.js
@@ -5,11 +5,6 @@ function checkPromise(p) {
 }
 
 
-var nextTick = typeof setImmediate !== 'undefined'
-    ? setImmediate
-    : process.nextTick
-;
-
 Test.prototype.run = function () {
     if (this._skip) 
         return this.end();


### PR DESCRIPTION
Looks like some ancient leftover.

One test failed before the change and keeps failing after the change – but it looks like it should be so (https://github.com/spion/blue-tape/pull/10).