### PR TITLE
Use isPromise instead of calling checkPromise(p)

### DIFF
--- a/blue-tape.js
+++ b/blue-tape.js
@@ -13,7 +13,7 @@ Test.prototype.run = function () {
         var p = this._cb && this._cb(this),
             isPromise = checkPromise(p)
         var self = this;
-        if (checkPromise(p))
+        if (isPromise)
             p.then(function() {
                 self.end();
             }, function(err) {


### PR DESCRIPTION
I noticed that `isPromise` was being defined, but wasn't actually being used.