### PR TITLE
Any rejected promise should be not ok

### DIFF
--- a/blue-tape.js
+++ b/blue-tape.js
@@ -6,7 +6,7 @@ function checkPromise(p) {
 
 
 Test.prototype.run = function () {
-    if (this._skip) 
+    if (this._skip)
         return this.end();
     this.emit('prerun');
     try {
@@ -17,13 +17,13 @@ Test.prototype.run = function () {
             p.then(function() {
                 self.end();
             }, function(err) {
-                self.error(err);
+                err ? self.error(err) : self.fail(err);
                 self.end();
-            })        
+            })
 
     }
     catch (err) {
-        this.error(err);
+        err ? self.error(err) : self.fail(err);
         this.end();
         return;
     }

--- a/test/primary.js
+++ b/test/primary.js
@@ -37,10 +37,14 @@ test("inner", function(t) {
 });
 
 
-test("should fail", function(t) {
+test("should error", function(t) {
     return delay(1).then(function() {
         throw new Error("Failed!");
     });
 });
 
-
+test("should fail", function(t) {
+    return delay(1).then(function() {
+        return P.reject();
+    });
+});


### PR DESCRIPTION
Using `.error()` to handle rejected values will not fail if the value is
falsy. Now the reason for the rejected is inspected and `.error()` is used
if truthy, `.fail()` if falsy.