### PR TITLE
Add shouldFail for tests that expect errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ it will be checked for errors. If there are no errors, the test
 will end. Otherwise the test will fail. This means there is no
 need to use `t.plan()` or `t.end()`
 
+Also provides `t.shouldFail(promise P, optional class C)` which returns
+a new promise that resolves successfully iff `P` rejects. If you provide 
+the optional class, then it additiionally ensures that `err` is an
+instance of that class.
+
 ### example
 
 assuming `delay()` returns a promise
@@ -23,6 +28,14 @@ test("should fail", function(t) {
     return delay(1).then(function() {
         throw new Error("Failed!");
     });
+});
+```
+
+assuming `failDelay()` returns a promise that rejects with a DerpError
+
+```js
+test("promise fails but test succeeds", function(t) {
+    return t.shouldFail(failDelay(), DerpError)
 });
 ```
 

--- a/bin/blue-tape.js
+++ b/bin/blue-tape.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require('tape/bin/tape');
+require('tape/bin/tape')

--- a/blue-tape.js
+++ b/blue-tape.js
@@ -30,4 +30,15 @@ Test.prototype.run = function () {
     this.emit('run');
 };
 
+Test.prototype.shouldFail = function (promise, clazz) {
+    return promise.then(function() {
+        throw new Error('should have failed');
+    }, function(err) {
+        if (clazz && !(err instanceof clazz)) {
+            throw new Error('should have thrown an instance of ' + clazz)
+        }
+        this.ok(true)
+    }.bind(this));
+}
+
 module.exports = require('tape');

--- a/blue-tape.js
+++ b/blue-tape.js
@@ -1,44 +1,47 @@
-var Test = require('tape/lib/test');
+var Test = require('tape/lib/test')
 
-function checkPromise(p) {
-    return p && p.then && typeof p.then === 'function';
+function checkPromise (p) {
+  return p && p.then && typeof p.then === 'function'
 }
-
 
 Test.prototype.run = function () {
-    if (this._skip)
-        return this.end();
-    this.emit('prerun');
-    try {
-        var p = this._cb && this._cb(this),
-            isPromise = checkPromise(p)
-        var self = this;
-        if (isPromise)
-            p.then(function() {
-                self.end();
-            }, function(err) {
-                err ? self.error(err) : self.fail(err);
-                self.end();
-            })
-
+  if (this._skip) {
+    return this.end()
+  }
+  this.emit('prerun')
+  try {
+    var p = this._cb && this._cb(this)
+    var isPromise = checkPromise(p)
+    var self = this
+    if (isPromise) {
+      p.then(function () {
+        self.end()
+      }, function (err) {
+        err ? self.error(err) : self.fail(err)
+        self.end()
+      })
     }
-    catch (err) {
-        err ? this.error(err) : this.fail(err);
-        this.end();
-        return;
+  } catch (err) {
+    if (err) {
+      this.error(err)
+    } else {
+      this.fail(err)
     }
-    this.emit('run');
-};
-
-Test.prototype.shouldFail = function (promise, clazz) {
-    return promise.then(function() {
-        throw new Error('should have failed');
-    }, function(err) {
-        if (clazz && !(err instanceof clazz)) {
-            throw new Error('should have thrown an instance of ' + clazz)
-        }
-        this.ok(true)
-    }.bind(this));
+    this.end()
+    return
+  }
+  this.emit('run')
 }
 
-module.exports = require('tape');
+Test.prototype.shouldFail = function (promise, clazz) {
+  return promise.then(function () {
+    throw new Error('should have failed')
+  }, function (err) {
+    if (clazz && !(err instanceof clazz)) {
+      throw new Error('should have thrown an instance of ' + clazz)
+    }
+    this.ok(true)
+  }.bind(this))
+}
+
+module.exports = require('tape')

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "blue-tape": "./bin/blue-tape.js"
   },
   "scripts": {
-    "test": "node test/index.js"
+    "test": "standard && node test/index.js"
   },
   "keywords": [
     "tape",
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "bl": "^1.0.0",
-    "bluebird": "^2.1.2"
+    "bluebird": "^2.1.2",
+    "standard": "*"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,123 +1,121 @@
-var tape = require('../blue-tape');
+var tape = require('../blue-tape')
 var bl = require('bl')
-var P = require('bluebird');
-P.longStackTraces();
+var P = require('bluebird')
+P.longStackTraces()
 
-function test(name, test, checkErrors) {
-    tape.test(name, function(t) {
-        var htest = tape.createHarness();
-        htest.createStream().pipe(bl(function(err, data) {
-            checkErrors && checkErrors(data.toString().split('\n'), t);
-        }))
-        htest(function(t) {
-            return test(t, htest);
-        });
-    });
+function test (name, test, checkErrors) {
+  tape.test(name, function (t) {
+    var htest = tape.createHarness()
+    htest.createStream().pipe(bl(function (_, data) {
+      checkErrors && checkErrors(data.toString().split('\n'), t)
+    }))
+    htest(function (t) {
+      return test(t, htest)
+    })
+  })
 }
 
-function verifyAsserts(counts) {
-    return function(lines, t) {
-        t.equal(count(lines, /^ok/), counts.ok, "should have " + counts.ok + " ok asserts")
-        t.equal(count(lines, /^not ok/), counts.fail, "should have " + counts.fail + " failed asserts")
-        t.end()
+function verifyAsserts (counts) {
+  return function (lines, t) {
+    t.equal(count(lines, /^ok/), counts.ok, 'should have ' + counts.ok + ' ok asserts')
+    t.equal(count(lines, /^not ok/), counts.fail, 'should have ' + counts.fail + ' failed asserts')
+    t.end()
+  }
+}
+
+function count (lines, regex) {
+  var c = 0
+  for (var k = 0; k < lines.length; ++k) {
+    if (regex.test(lines[k])) {
+      ++c
     }
+  }
+  return c
 }
 
-function count(lines, regex) {
-    var c = 0;
-    for (var k = 0; k < lines.length; ++k) {
-        if (regex.test(lines[k])) ++c
-    }
-    return c;
-}
+test('non-promise test', function (t) {
+  t.ok(true)
+  t.end()
+},
+  verifyAsserts({ok: 1, fail: 0}))
 
-test("non-promise test", function(t) {
-    t.ok(true);
-    t.end();
-  },
-  verifyAsserts({ok: 1, fail: 0}));
+test('simple delay', function (t) {
+  return P.delay(1)
+},
+  verifyAsserts({ok: 0, fail: 0}))
 
-test("simple delay", function(t) {
-    return P.delay(1);
-  },
-  verifyAsserts({ok: 0, fail: 0}));
+test('should not affect plan', function (t) {
+  t.plan(2)
+  t.ok(true)
+  t.ok(true)
+  return P.delay(1)
+},
+  verifyAsserts({ok: 2, fail: 0}))
 
-test("should not affect plan", function(t) {
-    t.plan(2);
-    t.ok(true);
-    t.ok(true);
-    return P.delay(1);
-  },
-  verifyAsserts({ok: 2, fail: 0}));
+test('nested tests with promises', function (t) {
+  t.test('delay1', function (t) {
+    return P.delay(1)
+  })
+  t.test('delay2', function () {
+    return P.delay(1)
+  })
+},
+  verifyAsserts({ok: 0, fail: 0}))
 
-test("nested tests with promises", function(t) {
-    t.test("delay1", function(t) {
-        return P.delay(1);
-    });
-    t.test("delay2", function() {
-        return P.delay(1);
-    });
-  },
-  verifyAsserts({ok: 0, fail: 0}));
+test('should error', function (t) {
+  return P.delay(1).then(function () {
+    throw new Error('Failed!')
+  })
+},
+  verifyAsserts({ok: 0, fail: 1}))
 
+test('should fail', function (t) {
+  return P.delay(1).then(function () {
+    return P.reject()
+  })
+},
+  verifyAsserts({ok: 0, fail: 1}))
 
-test("should error", function(t) {
-    return P.delay(1).then(function() {
-        throw new Error("Failed!");
-    });
-  },
-  verifyAsserts({ok: 0, fail: 1}));
+test('run test with only', function (t, htest) {
+  var count = 0
+  htest('first', function (t) {
+    t.equal(++count, 1)
+    t.end()
+  })
+  htest.only('second', function (t) {
+    t.equal(++count, 1)
+    t.end()
+  })
+  t.end()
+},
+  verifyAsserts({ok: 1, fail: 0}))
 
-test("should fail", function(t) {
-    return P.delay(1).then(function() {
-        return P.reject();
-    });
-  },
-  verifyAsserts({ok: 0, fail: 1}));
+test('test that expects promise to fail', function (t) {
+  return t.shouldFail(P.delay(1).then(function () {
+    return P.reject()
+  }))
+},
+  verifyAsserts({ok: 1, fail: 0}))
 
+test('test that expects promise to fail, but it succeeds', function (t) {
+  return t.shouldFail(P.delay(1).then(function () {
+    return P.resolve()
+  }))
+},
+  verifyAsserts({ok: 0, fail: 1}))
 
+test('test that expects specific exception', function (t) {
+  return t.shouldFail(P.delay(1).then(function () {
+    var f = 5
+    f.toFixed(100) // RangeError
+  }), RangeError)
+},
+  verifyAsserts({ok: 1, fail: 0}))
 
-test("run test with only", function(t, htest) {
-    var count = 0;
-    htest('first', function(t){
-        t.equal( ++count, 1);
-        t.end();
-    });
-    htest.only('second', function(t){
-        t.equal( ++count, 1);
-        t.end();
-    });
-    t.end();
-  },
-  verifyAsserts({ok: 1, fail: 0}));
-
-
-test("test that expects promise to fail", function(t) {
-    return t.shouldFail(P.delay(1).then(function() {
-        return P.reject();
-    }));
-  },
-  verifyAsserts({ok: 1, fail: 0}));
-
-test("test that expects promise to fail, but it succeeds", function(t) {
-    return t.shouldFail(P.delay(1).then(function() {
-        return P.resolve();
-    }));
-  },
-  verifyAsserts({ok: 0, fail: 1}));
-
-test("test that expects specific exception", function(t) {
-    return t.shouldFail(P.delay(1).then(function() {
-        var f = 5;
-        f.toFixed(100); // RangeError
-    }), RangeError);
-  },
-  verifyAsserts({ok: 1, fail: 0}));
-
-test("test that expects wrong exception", function(t) {
-    return t.shouldFail(P.delay(1).then(function() {
-        var f = 5;
-        f.toFixed(100); // RangeError
-    }), SyntaxError);
-  },
-  verifyAsserts({ok: 0, fail: 1}));
+test('test that expects wrong exception', function (t) {
+  return t.shouldFail(P.delay(1).then(function () {
+    var f = 5
+    f.toFixed(100) // RangeError
+  }), SyntaxError)
+},
+  verifyAsserts({ok: 0, fail: 1}))

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,4 @@
-
 var tape = require('../blue-tape');
-
 var bl = require('bl')
 var P = require('bluebird');
 P.longStackTraces();
@@ -92,3 +90,34 @@ test("run test with only", function(t, htest) {
     t.end();
   },
   verifyAsserts({ok: 1, fail: 0}));
+
+
+test("test that expects promise to fail", function(t) {
+    return t.shouldFail(P.delay(1).then(function() {
+        return P.reject();
+    }));
+  },
+  verifyAsserts({ok: 1, fail: 0}));
+
+test("test that expects promise to fail, but it succeeds", function(t) {
+    return t.shouldFail(P.delay(1).then(function() {
+        return P.resolve();
+    }));
+  },
+  verifyAsserts({ok: 0, fail: 1}));
+
+test("test that expects specific exception", function(t) {
+    return t.shouldFail(P.delay(1).then(function() {
+        var f = 5;
+        f.toFixed(100); // RangeError
+    }), RangeError);
+  },
+  verifyAsserts({ok: 1, fail: 0}));
+
+test("test that expects wrong exception", function(t) {
+    return t.shouldFail(P.delay(1).then(function() {
+        var f = 5;
+        f.toFixed(100); // RangeError
+    }), SyntaxError);
+  },
+  verifyAsserts({ok: 0, fail: 1}));


### PR DESCRIPTION
`t.shouldFail(promise P, optional class C)` returns a new promise that resolves successfully when P rejects. If you provide the optional class, then it additionally ensures that `err` is an instance of that class.

Because `shouldFail` returns a new promise, it also composes pretty nicely with tests that run multiple promises and expect some of them to fail, or with tests that use `co` and generators.

### Example

Assuming failDelay() returns a promise that rejects with a `DerpError`

```js
test("promise fails but test succeeds", function(t) {
    return t.shouldFail(failDelay(), DerpError)
});
```